### PR TITLE
chore: remove karma suffix from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# test-whatwg-fetch-karma
-Attempts to write tests for WHATWG fetch in browsers using karma
+# test-whatwg-fetch
+
+Attempts to write tests for WHATWG fetch in browsers

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "test-whatwg-fetch-karma",
+  "name": "test-whatwg-fetch",
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
     "test": "karma start karma.conf.js"
   },
-  "repository": "git@github.com:trivikr/test-whatwg-fetch-karma.git",
+  "repository": "git@github.com:trivikr/test-whatwg-fetch.git",
   "author": "Kamat, Trivikram <trivikr.dev@gmail.com>",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4426,9 +4426,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"test-whatwg-fetch-karma@workspace:.":
+"test-whatwg-fetch@workspace:.":
   version: 0.0.0-use.local
-  resolution: "test-whatwg-fetch-karma@workspace:."
+  resolution: "test-whatwg-fetch@workspace:."
   dependencies:
     "@tsconfig/node14": ^1.0.3
     "@types/jasmine": ^4.3.1


### PR DESCRIPTION
karma test runner has been deprecated https://github.com/karma-runner/karma/pull/3846